### PR TITLE
fix: use SI gigabytes (1000^3) instead of binary gibibytes (1024^3)

### DIFF
--- a/internal/jobs/manager.go
+++ b/internal/jobs/manager.go
@@ -483,7 +483,7 @@ func (m *Manager) ProvisionVolume(ctx context.Context, job *Job) error {
 	estimator := timing.NewEstimator(downloadRate, convertRate)
 
 	var downloadSize, convertSize int64
-	convertSize = int64(req.VolumeSizeGB) * 1024 * 1024 * 1024
+	convertSize = int64(req.VolumeSizeGB) * 1000 * 1000 * 1000
 	if req.ImageType == "qcow2" {
 		downloadSize = convertSize / 5
 	} else {

--- a/internal/lvm/manager.go
+++ b/internal/lvm/manager.go
@@ -111,7 +111,7 @@ func (m *Manager) CreateVolume(ctx context.Context, volumeName string, sizeGB in
 func (m *Manager) createVolumeOnce(ctx context.Context, volumeName string, sizeGB int) error {
 	// Create LVM volume
 	cmd := exec.CommandContext(ctx, "lvcreate",
-		"-L", fmt.Sprintf("%dG", sizeGB),
+		"-L", fmt.Sprintf("%dg", sizeGB),
 		"-n", volumeName, m.vgName)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -463,7 +463,7 @@ func (m *Manager) validateExistingVolume(ctx context.Context, volumeName string,
 	}
 
 	// Check size (allow some tolerance for filesystem overhead)
-	requiredSizeBytes := int64(requiredSizeGB) * 1024 * 1024 * 1024
+	requiredSizeBytes := int64(requiredSizeGB) * 1000 * 1000 * 1000
 	actualSizeBytes := info.SizeBytes
 
 	// Allow 5% variance for filesystem/formatting differences

--- a/internal/lvm/manager_test.go
+++ b/internal/lvm/manager_test.go
@@ -50,12 +50,12 @@ func TestVolumeInfo(t *testing.T) {
 	// Test VolumeInfo struct creation
 	info := &VolumeInfo{
 		Name:       "test-volume",
-		SizeBytes:  1073741824, // 1GB
+		SizeBytes:  1000000000, // 1GB
 		Attributes: "-wi-a-----",
 	}
 
 	assert.Equal(t, "test-volume", info.Name)
-	assert.Equal(t, int64(1073741824), info.SizeBytes)
+	assert.Equal(t, int64(1000000000), info.SizeBytes)
 	assert.Equal(t, "-wi-a-----", info.Attributes)
 }
 


### PR DESCRIPTION
## Summary

The `volume_size_gb` API field is named for SI gigabytes (1000^3), but the code was treating the value as binary gibibytes (1024^3) in three places:

- `internal/lvm/manager.go`: `lvcreate -L %dG` — LVM uppercase `G` means GiB, changed to lowercase `g` for GB
- `internal/lvm/manager.go`: `requiredSizeBytes` calculation — changed `* 1024^3` to `* 1000^3`
- `internal/jobs/manager.go`: `convertSize` calculation — changed `* 1024^3` to `* 1000^3`
- `internal/lvm/manager_test.go`: Updated test value from 1073741824 (1 GiB) to 1000000000 (1 GB)

### Impact

Previously, requesting `volume_size_gb: 50` created a 50 GiB volume (~53.7 GB). Now it correctly creates a 50 GB volume (50,000,000,000 bytes).